### PR TITLE
Actually pass the merge parameter along to the server

### DIFF
--- a/acceptance/lookup_test.go
+++ b/acceptance/lookup_test.go
@@ -81,3 +81,31 @@ func TestLookupMetadata(t *testing.T) {
 	expected := fixtures.LookupMetadataResult
 	assert.Equal(t, expected, *actual)
 }
+
+func TestLookupHashMerge(t *testing.T) {
+	if v := os.Getenv("JERAKIA_ACC"); v == "" {
+		t.Skip("JERAKIA_ACC not set")
+	}
+
+	client, err := NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lookupOpts := &jerakia.LookupOpts{
+		Namespace: "test",
+		Metadata: map[string]string{
+			"env": "dev",
+		},
+		LookupType: "cascade",
+		Merge: "hash",
+	}
+
+	actual, err := jerakia.Lookup(client, "hash", lookupOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := fixtures.LookupHashMergeResult
+	assert.Equal(t, expected, *actual)
+}

--- a/lookup.go
+++ b/lookup.go
@@ -52,6 +52,10 @@ func (opts LookupOpts) ToLookupQuery() (string, error) {
 		params.Add("lookup_type", opts.LookupType)
 	}
 
+	if opts.Merge != "" {
+		params.Add("merge", opts.Merge)
+	}
+
 	if opts.Scope != "" {
 		params.Add("scope", opts.Scope)
 	}

--- a/testing/lookup_fixtures.go
+++ b/testing/lookup_fixtures.go
@@ -110,3 +110,59 @@ func HandleLookupMetadata(t *testing.T) {
 		fmt.Fprintf(w, LookupMetadataResponse)
 	})
 }
+
+// LookupHashMergeResponse is the expected response of a hash merge lookup.
+const LookupHashMergeResponse = `
+{
+    "found": true,
+    "payload": {
+			"key0": {
+				"element0": "common"
+			},
+      "key1": {
+				"element2": "env"
+			},
+			"key2": {
+				"element3": {
+					"subelement3": "env"
+				}
+			},
+			"key3": "env"
+    },
+    "status": "ok"
+}
+`
+
+// LookupHashMergeResult is the expected result of a hash merge lookup.
+var LookupHashMergeResult = jerakia.LookupResult{
+	Status: "ok",
+	Found:  true,
+	Payload: map[string]interface{}{
+		"key0": map[string]interface{}{
+			"element0": "common",
+		},
+		"key1": map[string]interface{}{
+			"element2": "env",
+		},
+		"key2": map[string]interface{}{
+			"element3": map[string]interface{}{
+				"subelement3": "env",
+			},
+		},
+		"key3": "env",
+	},
+}
+
+// HandleLookupHashMerge tests a hash merge lookup.
+func HandleLookupHashMerge(t *testing.T) {
+	th.Mux.HandleFunc("/lookup/hash", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, fake.Token, r.Header.Get("X-Authentication"))
+		assert.Equal(t, []string{"cascade"}, r.URL.Query()["lookup_type"])
+		assert.Equal(t, []string{"hash"}, r.URL.Query()["merge"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, LookupHashMergeResponse)
+	})
+}

--- a/testing/lookup_requests_test.go
+++ b/testing/lookup_requests_test.go
@@ -66,3 +66,26 @@ func TestLookupMetadata(t *testing.T) {
 	expected := LookupMetadataResult
 	assert.Equal(t, expected, *actual)
 }
+
+func TestLookupHashMerge(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleLookupHashMerge(t)
+
+	lookupOpts := &jerakia.LookupOpts{
+		Namespace: "test",
+		Metadata: map[string]string{
+			"environment": "dev",
+		},
+		LookupType: "cascade",
+		Merge: "hash",
+	}
+
+	actual, err := jerakia.Lookup(fake.FakeClient(), "hash", lookupOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := LookupHashMergeResult
+	assert.Equal(t, expected, *actual)
+}


### PR DESCRIPTION
The `Merge` lookup option was previously ignored and never added to the query parameters sent to the server. This PR fixes that. Tests included.