### PR TITLE
Add support for keyless lookups

### DIFF
--- a/acceptance/fixtures/var/lib/jerakia/data/common/keyless.yaml
+++ b/acceptance/fixtures/var/lib/jerakia/data/common/keyless.yaml
@@ -1,0 +1,2 @@
+foo: bar
+hello: world

--- a/acceptance/lookup_test.go
+++ b/acceptance/lookup_test.go
@@ -81,3 +81,26 @@ func TestLookupMetadata(t *testing.T) {
 	expected := fixtures.LookupMetadataResult
 	assert.Equal(t, expected, *actual)
 }
+
+func TestLookupKeyless(t *testing.T) {
+	if v := os.Getenv("JERAKIA_ACC"); v == "" {
+		t.Skip("JERAKIA_ACC not set")
+	}
+
+	client, err := NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lookupOpts := &jerakia.LookupOpts{
+		Namespace: "keyless",
+	}
+
+	actual, err := jerakia.Lookup(client, "", lookupOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := fixtures.LookupKeylessResult
+	assert.Equal(t, expected, *actual)
+}

--- a/lookup.go
+++ b/lookup.go
@@ -91,7 +91,11 @@ type LookupResult struct {
 // Lookup performs a lookup.
 func Lookup(client *Client, key string, opts *LookupOpts) (*LookupResult, error) {
 	var r LookupResult
-	url := client.config.URL + "/" + LookupURL + "/" + key
+	url := client.config.URL + "/" + LookupURL
+
+	if key != "" {
+		url += ("/" + key)
+	}
 
 	if opts != nil {
 		query, err := opts.ToLookupQuery()

--- a/testing/lookup_fixtures.go
+++ b/testing/lookup_fixtures.go
@@ -110,3 +110,40 @@ func HandleLookupMetadata(t *testing.T) {
 		fmt.Fprintf(w, LookupMetadataResponse)
 	})
 }
+
+// LookupKeylessResponse is the expected response of a keyless lookup.
+const LookupKeylessResponse = `
+{
+    "found": true,
+    "payload": {
+			"foo": "bar",
+			"hello": "world"
+    },
+    "status": "ok"
+}
+`
+
+// LookupKeylessResult is the expected result of a keyless lookup.
+var LookupKeylessResult = jerakia.LookupResult{
+	Status: "ok",
+	Found:  true,
+	Payload: map[string]interface{}{
+		"foo": "bar",
+		"hello": "world",
+	},
+}
+
+// HandleLookupKeyless tests a keyless lookup.
+func HandleLookupKeyless(t *testing.T) {
+	th.Mux.HandleFunc("/lookup", func(w http.ResponseWriter, r *http.Request) {
+
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, fake.Token, r.Header.Get("X-Authentication"))
+		assert.Equal(t, []string{"keyless"}, r.URL.Query()["namespace"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, LookupKeylessResponse)
+	})
+}
+

--- a/testing/lookup_requests_test.go
+++ b/testing/lookup_requests_test.go
@@ -66,3 +66,21 @@ func TestLookupMetadata(t *testing.T) {
 	expected := LookupMetadataResult
 	assert.Equal(t, expected, *actual)
 }
+
+func TestLookupKeyless(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleLookupKeyless(t)
+
+	lookupOpts := &jerakia.LookupOpts{
+		Namespace: "keyless",
+	}
+
+	actual, err := jerakia.Lookup(fake.FakeClient(), "", lookupOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := LookupKeylessResult
+	assert.Equal(t, expected, *actual)
+}


### PR DESCRIPTION
This PR adds supports for keyless lookups by using `""` as a lookup key (because Go doesn't really support optional arguments, or passing `nil` instead of a string, or anything like that, and I didn't want to break the existing API).

An alternative fix would be to just move the key into the LookupOptions struct, which I think would be more elegant, but it'd be a breaking change.